### PR TITLE
Feature/install examples

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include *.py *.json *.sh MANIFEST.in README.md CHANGES.md LICENSE.md VERSION
+recursive-include src      *.sh
+recursive-include examples *

--- a/setup.py
+++ b/setup.py
@@ -124,11 +124,8 @@ setup_args = {
                            'bin/ensemblemd-profile'],
 
     'package_data'      :  {'': ['*.sh', '*.json', 'VERSION', 'VERSION.git']},
-<<<<<<< HEAD
     'install_requires'  :  ['radical.utils==0.35','saga-python==0.35','radical.pilot==0.35', 'setuptools>=1'],
-=======
     'install_requires'  :  ['radical.pilot', 'setuptools>=1'],
->>>>>>> RC_changes
 
     'test_suite'        : 'radical.ensemblemd.tests',
 

--- a/setup.py
+++ b/setup.py
@@ -72,6 +72,81 @@ def get_version():
 
     return short_version, long_version
 
+# ------------------------------------------------------------------------------
+#
+# borrowed from the MoinMoin-wiki installer
+#
+def makeDataFiles(prefix, dir):
+    """ Create distutils data_files structure from dir
+
+    distutil will copy all file rooted under dir into prefix, excluding
+    dir itself, just like 'ditto src dst' works, and unlike 'cp -r src
+    dst, which copy src into dst'.
+
+    Typical usage:
+        # install the contents of 'wiki' under sys.prefix+'share/moin'
+        data_files = makeDataFiles('share/moin', 'wiki')
+
+    For this directory structure:
+        root
+            file1
+            file2
+            dir
+                file
+                subdir
+                    file
+
+    makeDataFiles('prefix', 'root')  will create this distutil data_files structure:
+        [('prefix', ['file1', 'file2']),
+         ('prefix/dir', ['file']),
+         ('prefix/dir/subdir', ['file'])]
+
+    """
+    # Strip 'dir/' from of path before joining with prefix
+    dir = dir.rstrip('/')
+    strip = len(dir) + 1
+    found = []
+    os.path.walk(dir, visit, (prefix, strip, found))
+    return found
+
+def visit((prefix, strip, found), dirname, names):
+    """ Visit directory, create distutil tuple
+
+    Add distutil tuple for each directory using this format:
+        (destination, [dirname/file1, dirname/file2, ...])
+
+    distutil will copy later file1, file2, ... info destination.
+    """
+    files = []
+    # Iterate over a copy of names, modify names
+    for name in names[:]:
+        path = os.path.join(dirname, name)
+        # Ignore directories -  we will visit later
+        if os.path.isdir(path):
+            # Remove directories we don't want to visit later
+            if isbad(name):
+                names.remove(name)
+            continue
+        elif isgood(name):
+            files.append(path)
+    destination = os.path.join(prefix, dirname[strip:])
+    found.append((destination, files))
+
+def isbad(name):
+    """ Whether name should not be installed """
+    return (name.startswith('.') or
+            name.startswith('#') or
+            name.endswith('.pickle') or
+            name == 'CVS')
+
+def isgood(name):
+    """ Whether name should be installed """
+    if not isbad(name):
+        if name.endswith('.py') or name.endswith('.json'):
+            return True
+    return False
+
+
 #-----------------------------------------------------------------------------
 #
 srcroot = os.path.dirname(os.path.realpath(__file__))
@@ -130,6 +205,10 @@ setup_args = {
     'test_suite'        : 'radical.ensemblemd.tests',
 
     'zip_safe'          : False,
+    # This copies the contents of the examples/ dir under
+    # sys.prefix/share/radical.pilot.
+    # It needs the MANIFEST.in entries to work.
+    'data_files'        : makeDataFiles('share/radical.pilot/examples/', 'examples'),
 }
 
 setup (**setup_args)

--- a/setup.py
+++ b/setup.py
@@ -208,7 +208,8 @@ setup_args = {
     # This copies the contents of the examples/ dir under
     # sys.prefix/share/radical.pilot.
     # It needs the MANIFEST.in entries to work.
-    'data_files'        : makeDataFiles('share/radical.pilot/examples/', 'examples'),
+    'data_files'        : makeDataFiles('share/radical.ensemblemd/examples/', 'examples'),
 }
 
 setup (**setup_args)
+


### PR DESCRIPTION
Hi Vivek -- this PR is supposed to install the repex `examples/` subtree under `$VE/share/radical.ensemblemd/examples/`.  Please check carefully that it does not break install otherwise before merge!

The purpose is that, during the tutorial, people don't need to run `wget` or `scp` to get the examples onto the workflow machine...