### PR TITLE
environment takes a dict of environment variables + values

### DIFF
--- a/doc/dev/dev_writing_kernels.rst
+++ b/doc/dev/dev_writing_kernels.rst
@@ -4,9 +4,14 @@
 Writing New Application Kernels
 --------------------------------------------------
 
-While the current set of available application kernels might provide a good set of tools to start, sooner or later you will probably want to use a tool for which no application Kernel exsits. This section describes how you can add your custom kernels. 
+While the current set of available application kernels might provide a good set
+of tools to start, sooner or later you will probably want to use a tool for
+which no application Kernel exsits. This section describes how you can add your
+custom kernels. 
 
-We have two files, user_script.py which contains the user application which **uses** our custom kernel, new_kernel.py which contains the definition of the custom kernel. You can download them from the following links:
+We have two files, user_script.py which contains the user application which
+**uses** our custom kernel, new_kernel.py which contains the definition of the
+custom kernel. You can download them from the following links:
 
 * :download:`user_script.py <../scripts/user_script.py>`
 * :download:`new_kernel.py <../scripts/new_kernel.py>`
@@ -18,9 +23,21 @@ Let's first take a look at ``new_kernel.py``.
         :language: python
         :linenos:
 
-Lines 5-24 contain information about the kernel to be defined. "name" and "arguments" keys are mandatory. The "arguments" key needs to specify the arguments the kernel expects. You can specify whether the individual arguments are mandatory or not. "machine_configs" is not mandatory, but creating a dictionary with resource labels as keys and values which are resource specific lets use the same kernel to be used on different machines.
+Lines 5-24 contain information about the kernel to be defined. "name" and
+"arguments" keys are mandatory. The "arguments" key needs to specify the
+arguments the kernel expects. You can specify whether the individual arguments
+are mandatory or not. "machine_configs" is not mandatory, but creating a
+dictionary with resource labels as keys and values which are resource specific
+lets use the same kernel to be used on different machines.
 
-In lines 28-52, we define a user defined class (of "KernelBase" type) with 3 mandatory functions. First the constructor, self-explanatory. Second, a static method that is used by EnsembleMD to differentiate kernels. Third, ``_bind_to_resource`` which is the function that (as the name suggests) binds the kernel with its resource specific values, during execution. In lines 48, 50-52, you can see how the "machine_configs" dictionary approach is helps us across different resources. The values in **lines 48-52 are the definitions of the kernel**.
+In lines 28-52, we define a user defined class (of "KernelBase" type) with 3
+mandatory functions. First the constructor, self-explanatory. Second, a static
+method that is used by EnsembleMD to differentiate kernels. Third,
+``_bind_to_resource`` which is the function that (as the name suggests) binds
+the kernel with its resource specific values, during execution. In lines 48,
+50-52, you can see how the "machine_configs" dictionary approach is helps us
+across different resources. The values in **lines 48-52 are the definitions of
+the kernel**.
 
 Now, let's take a look at ``user_script.py``
 
@@ -28,4 +45,8 @@ Now, let's take a look at ``user_script.py``
         :language: python
         :linenos:
 
-There are 3 important lines in this script. In line 7, we import the get_engine function in order to register our new kernel. In line 10, we import our new kernel and in line 13, we register our kernel. **THAT'S IT**. We can continue with the application as in the previous examples.
+There are 3 important lines in this script. In line 7, we import the get_engine
+function in order to register our new kernel. In line 10, we import our new
+kernel and in line 13, we register our kernel. **THAT'S IT**. We can continue
+with the application as in the previous examples.
+

--- a/doc/scripts/new_kernel.py
+++ b/doc/scripts/new_kernel.py
@@ -3,22 +3,22 @@ from radical.ensemblemd.kernel_plugins.kernel_base import KernelBase
 # ------------------------------------------------------------------------------
 #
 _KERNEL_INFO = {
-    "name":         "sleep",        #Mandatory
-    "description":  "sleeping kernel",        #Optional
-    "arguments":   {                #Mandatory
+    "name":         "sleep",                  # Mandatory
+    "description":  "sleeping kernel",        # Optional
+    "arguments":   {                          # Mandatory
         "--interval=": {
-            "mandatory": True,        #Mandatory argument? True or False
+            "mandatory": True,                # Mandatory argument? True or False
             "description": "Number of seconds to do nothing."
     	    },
         },
-    "machine_configs":             #Use a dictionary with keys as resource 
-        {                                       #names and values specific to the resource
-            "local.localhost":
+    "machine_configs":                        # Use a dictionary with keys as
+        {                                     # resource names and values specific
+            "local.localhost":                # to the resource
             {
-                "environment" : None,        #list or None, can be used to set env variables
-                "pre_exec"    : None,            #list or None, can be used to load modules
-                "executable"  : ["/bin/sleep"],        #specify the executable to be used
-                "uses_mpi"    : False            #mpi-enabled? True or False
+                "environment" : None,         # dict or None, can be used to set env variables
+                "pre_exec"    : None,         # list or None, can be used to load modules
+                "executable"  : ["/bin/sleep"],        # specify the executable to be used
+                "uses_mpi"    : False         # mpi-enabled? True or False
             },
         }
 }


### PR DESCRIPTION
fix to doc example for kernel specification

The docs currently say that environment variables are set with a list, but instances of `Kernel`s defined in the library use a dict here, which makes more sense anyway.